### PR TITLE
Remove unused Levenshtein dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "peewee",
     "PyGObject",
     "python-dateutil",
-    "Levenshtein",
     "python-mpv",
     "requests",
     "semver",


### PR DESCRIPTION
This simple PR just removes the Levenshtein dependency in pyproject.toml, since the package is not used at all.