### PR TITLE
Fix ordering multiple CD releases in album page

### DIFF
--- a/sublime_music/adapters/filesystem/adapter.py
+++ b/sublime_music/adapters/filesystem/adapter.py
@@ -758,7 +758,7 @@ class FilesystemAdapter(CachingAdapter):
         elif data_key == KEYS.SONG:
             api_song = cast(API.Song, data)
             song_data = getattrs(
-                api_song, ["id", "title", "track", "year", "duration", "parent_id"]
+                api_song, ["id", "title", "track", "year", "duration", "parent_id", "disc_number"]
             )
             song_data["genre"] = (
                 self._do_ingest_new_data(KEYS.GENRE, None, g) if (g := api_song.genre) else None


### PR DESCRIPTION
The disc number was not saved in the cache database. 
This patch add the disc_number to the data to save.

Closes #337