### PR TITLE
Make mpris compatible with kde

### DIFF
--- a/sublime_music/dbus/manager.py
+++ b/sublime_music/dbus/manager.py
@@ -72,13 +72,13 @@ class DBusManager:
                 with open(spec_path) as f:
                     node_info = Gio.DBusNodeInfo.new_for_xml(f.read())
 
-                    connection.register_object(
-                        "/org/mpris/MediaPlayer2",
-                        node_info.interfaces[0],
-                        self.on_method_call,
-                        self.on_get_property,
-                        self.on_set_property,
-                    )
+                connection.register_object(
+                    "/org/mpris/MediaPlayer2",
+                    node_info.interfaces[0],
+                    self.on_method_call,
+                    self.on_get_property,
+                    self.on_set_property,
+                )
 
         # TODO (#127): I have no idea what to do here.
         def dbus_name_lost(*args):

--- a/sublime_music/dbus/manager.py
+++ b/sublime_music/dbus/manager.py
@@ -60,7 +60,7 @@ class DBusManager:
         self.on_set_property = on_set_property
         self.connection = connection
 
-        def dbus_name_acquired(connection: Gio.DBusConnection, name: str):
+        def dbus_bus_acquired(connection: Gio.DBusConnection, name: str):
             specs = [
                 "org.mpris.MediaPlayer2.xml",
                 "org.mpris.MediaPlayer2.Player.xml",
@@ -72,23 +72,24 @@ class DBusManager:
                 with open(spec_path) as f:
                     node_info = Gio.DBusNodeInfo.new_for_xml(f.read())
 
-                connection.register_object(
-                    "/org/mpris/MediaPlayer2",
-                    node_info.interfaces[0],
-                    self.on_method_call,
-                    self.on_get_property,
-                    self.on_set_property,
-                )
+                    connection.register_object(
+                        "/org/mpris/MediaPlayer2",
+                        node_info.interfaces[0],
+                        self.on_method_call,
+                        self.on_get_property,
+                        self.on_set_property,
+                    )
 
         # TODO (#127): I have no idea what to do here.
         def dbus_name_lost(*args):
             pass
 
-        self.bus_number = Gio.bus_own_name_on_connection(
-            connection,
+        self.bus_number = Gio.bus_own_name(
+            Gio.BusType.SESSION,
             "org.mpris.MediaPlayer2.sublimemusic",
             Gio.BusNameOwnerFlags.NONE,
-            dbus_name_acquired,
+            dbus_bus_acquired,
+            None,
             dbus_name_lost,
         )
 


### PR DESCRIPTION
I don't know if the interface is not ready when KDE starts querying it, but making this change to the codebase gets MPRIS registered correctly.

The connection object didn't seem to change when calling the new function, I looked at the differences between bus_own_name_on_connection and bus_own_name, the former calls to has_connection (which already has) and the latter calls to bus_get. I tried some combinations by adding a call to bus_get* but I couldn't get it to work.

This code fixes #349, #41, works on Gnome, and puts to rest my former PR #442.

![image](https://github.com/sublime-music/sublime-music/assets/47254555/c573a95b-3afb-44b2-8e98-80060b8e8664)
